### PR TITLE
fix: serialize ActivityListener-based OTel tests to stop cross-test flakiness

### DIFF
--- a/tests/Langfuse.Tests/OpenTelemetry/ActivityListenerCollection.cs
+++ b/tests/Langfuse.Tests/OpenTelemetry/ActivityListenerCollection.cs
@@ -1,0 +1,9 @@
+namespace zborek.Langfuse.Tests.OpenTelemetry;
+
+/// <summary>
+///     ActivityListeners are process-global and match ActivitySources by name, so test classes that
+///     register listeners capture activities created by other classes running in parallel. Grouping
+///     them in one collection forces serial execution and prevents cross-test contamination.
+/// </summary>
+[CollectionDefinition("ActivityListener tests")]
+public class ActivityListenerCollection;

--- a/tests/Langfuse.Tests/OpenTelemetry/GenAiActivityHelperTests.cs
+++ b/tests/Langfuse.Tests/OpenTelemetry/GenAiActivityHelperTests.cs
@@ -5,6 +5,7 @@ using zborek.Langfuse.OpenTelemetry.Models;
 
 namespace zborek.Langfuse.Tests.OpenTelemetry;
 
+[Collection("ActivityListener tests")]
 public class GenAiActivityHelperTests : IDisposable
 {
     private readonly ActivitySource _activitySource;
@@ -18,7 +19,7 @@ public class GenAiActivityHelperTests : IDisposable
 
         _listener = new ActivityListener
         {
-            ShouldListenTo = _ => true,
+            ShouldListenTo = source => source.Name == "TestSource",
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
             ActivityStarted = activity => _capturedActivities.Add(activity)
         };

--- a/tests/Langfuse.Tests/OpenTelemetry/LangfuseFilteringExporterTests.cs
+++ b/tests/Langfuse.Tests/OpenTelemetry/LangfuseFilteringExporterTests.cs
@@ -5,6 +5,7 @@ using zborek.Langfuse.OpenTelemetry;
 
 namespace zborek.Langfuse.Tests.OpenTelemetry;
 
+[Collection("ActivityListener tests")]
 public class LangfuseFilteringExporterTests : IDisposable
 {
     private const string SourceName = "LangfuseFilteringExporterTests";

--- a/tests/Langfuse.Tests/OpenTelemetry/OtelLangfuseTraceStartTraceTests.cs
+++ b/tests/Langfuse.Tests/OpenTelemetry/OtelLangfuseTraceStartTraceTests.cs
@@ -7,6 +7,7 @@ using zborek.Langfuse.OpenTelemetry.Trace;
 
 namespace zborek.Langfuse.Tests.OpenTelemetry;
 
+[Collection("ActivityListener tests")]
 public class OtelLangfuseTraceStartTraceTests : IDisposable
 {
     private readonly ConcurrentBag<Activity> _capturedActivities;

--- a/tests/Langfuse.Tests/OpenTelemetry/OtelLangfuseTraceTests.cs
+++ b/tests/Langfuse.Tests/OpenTelemetry/OtelLangfuseTraceTests.cs
@@ -7,6 +7,7 @@ using zborek.Langfuse.OpenTelemetry.Trace;
 
 namespace zborek.Langfuse.Tests.OpenTelemetry;
 
+[Collection("ActivityListener tests")]
 public class OtelLangfuseTraceTests : IDisposable
 {
     private readonly ActivitySource _activitySource;

--- a/tests/Langfuse.Tests/OpenTelemetry/OtelObservationTests.cs
+++ b/tests/Langfuse.Tests/OpenTelemetry/OtelObservationTests.cs
@@ -8,6 +8,7 @@ using zborek.Langfuse.OpenTelemetry.Trace;
 
 namespace zborek.Langfuse.Tests.OpenTelemetry;
 
+[Collection("ActivityListener tests")]
 public class OtelObservationTests : IDisposable
 {
     private readonly ConcurrentBag<Activity> _capturedActivities;


### PR DESCRIPTION
## Problem

`OtelLangfuseTraceTests.CreateAgent_SetsAgentIdAndName` fails intermittently on CI:

```
agentActivity.GetTagItem(GenAiAttributes.AgentName)
    should be "test-agent" but was "TestAgent"
```

ActivityListeners are process-global and match ActivitySources by name, not instance. xUnit runs test classes in parallel, so a listener in one class captures activities created by another. `GenAiActivityHelperTests.CreateAgentActivity_SetsRequiredTags` creates an activity with DisplayName `test-agent` and AgentName tag `TestAgent`; when it runs concurrently, `OtelLangfuseTraceTests` captures it and its `FirstOrDefault(a => a.DisplayName == "test-agent")` picks the wrong activity. `GenAiActivityHelperTests` also listened with `ShouldListenTo = _ => true`, capturing everything.

## Fix

- Group all five ActivityListener-registering test classes into one xUnit collection (`ActivityListener tests`) so they run serially — no parallel cross-contamination.
- Scope the wildcard listener in `GenAiActivityHelperTests` to its own `TestSource`.

## Testing

- `dotnet test tests/Langfuse.Tests -f net10.0` run 3×: 708/708 passed each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)